### PR TITLE
8336035: Change JavaFX release version to 23.0.1 in jfx23u

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -24,7 +24,7 @@
 [general]
 project=openjfx
 jbs=jdk
-version=jfx23
+version=jfx23.0.1
 
 [repository]
 tags=(jdk-){0,1}([1-9]([0-9]*)(\.(0|[1-9][0-9]*)){0,3})(\+(([0-9]+))|(-ga))|[1-9]((\.\d{1,3}){0,2})-((b\d{2,3})|(ga))|[1-9]u(\d{1,3})-((b\d{2,3})|(ga))

--- a/build.properties
+++ b/build.properties
@@ -41,7 +41,7 @@ jfx.release.suffix=-ea
 # UPDATE THE FOLLOWING VALUES FOR A NEW RELEASE
 jfx.release.major.version=23
 jfx.release.minor.version=0
-jfx.release.security.version=0
+jfx.release.security.version=1
 jfx.release.patch.version=0
 
 # Note: The release version is now calculated in build.gradle as the


### PR DESCRIPTION
Updates for the beginning of the 23.0.1 release.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8336035](https://bugs.openjdk.org/browse/JDK-8336035) needs maintainer approval

### Issue
 * [JDK-8336035](https://bugs.openjdk.org/browse/JDK-8336035): Change JavaFX release version to 23.0.1 in jfx23u (**Task** - P2 - Approved)


### Reviewers
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx23u.git pull/1/head:pull/1` \
`$ git checkout pull/1`

Update a local copy of the PR: \
`$ git checkout pull/1` \
`$ git pull https://git.openjdk.org/jfx23u.git pull/1/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1`

View PR using the GUI difftool: \
`$ git pr show -t 1`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx23u/pull/1.diff">https://git.openjdk.org/jfx23u/pull/1.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx23u/pull/1#issuecomment-2224089422)