### PR TITLE
8335548: testCookieEnabled fails with WebKit 619.1

### DIFF
--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/MiscellaneousTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/MiscellaneousTest.java
@@ -217,9 +217,15 @@ public class MiscellaneousTest extends TestBase {
         }
     }
 
-    @Ignore("JDK-8335548")
-    @Test public void testCookieEnabled() {
+
+    @Test public void testCookieEnabled() throws Exception {
         final WebEngine webEngine = createWebEngine();
+        String location = new File("src/test/resources/test/html/cookie.html")
+                .toURI().toASCIIString().replaceAll("^file:/", "file:///");
+        Platform.runLater(() -> {
+            webEngine.load(location);
+        });
+        Thread.sleep(1000);
         submit(() -> {
             final JSObject window = (JSObject) webEngine.executeScript("window");
             assertNotNull(window);

--- a/modules/javafx.web/src/test/resources/test/html/cookie.html
+++ b/modules/javafx.web/src/test/resources/test/html/cookie.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+test cookie
+</body>
+</html>


### PR DESCRIPTION
A clean backport to jfx23u. The fix is for a test bug for cookie issue. WebView needs to load a dummy url before testing cookie. The test passes with the fix and fails without fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8335548](https://bugs.openjdk.org/browse/JDK-8335548) needs maintainer approval

### Issue
 * [JDK-8335548](https://bugs.openjdk.org/browse/JDK-8335548): testCookieEnabled fails with WebKit 619.1 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx23u.git pull/6/head:pull/6` \
`$ git checkout pull/6`

Update a local copy of the PR: \
`$ git checkout pull/6` \
`$ git pull https://git.openjdk.org/jfx23u.git pull/6/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6`

View PR using the GUI difftool: \
`$ git pr show -t 6`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx23u/pull/6.diff">https://git.openjdk.org/jfx23u/pull/6.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx23u/pull/6#issuecomment-2244962647)