### PR TITLE
8336277: Colors are incorrect when playing H.265/HEVC on Windows 11

### DIFF
--- a/modules/javafx.media/src/main/native/gstreamer/plugins/mfwrapper/mfwrapper.h
+++ b/modules/javafx.media/src/main/native/gstreamer/plugins/mfwrapper/mfwrapper.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,16 @@
 #include <mftransform.h>
 
 G_BEGIN_DECLS
+
+// Media Foundation Color Convert:
+// NV12 -> IYUV
+// P010 -> NV12 -> IYUV
+// Maximum number of color converters
+#define MAX_COLOR_CONVERT 2
+// Index in array for color convert with IYUV output format
+#define COLOR_CONVERT_IYUV 0
+// Index in array for color convert with NV12 output format
+#define COLOR_CONVERT_NV12 1
 
 #define GST_TYPE_MFWRAPPER \
     (gst_mfwrapper_get_type())
@@ -68,12 +78,10 @@ struct _GstMFWrapper
     HRESULT hr_mfstartup;
 
     IMFTransform *pDecoder;
-
     IMFSample *pDecoderOutput;
 
-    IMFTransform *pColorConvert;
-
-    IMFSample *pColorConvertOutput;
+    IMFTransform *pColorConvert[MAX_COLOR_CONVERT];
+    IMFSample *pColorConvertOutput[MAX_COLOR_CONVERT];
 
     BYTE *header;
     gsize header_size;
@@ -82,6 +90,10 @@ struct _GstMFWrapper
     guint height;
     guint framerate_num;
     guint framerate_den;
+
+    guint defaultStride;
+    guint pixel_num;
+    guint pixel_den;
 };
 
 struct _GstMFWrapperClass


### PR DESCRIPTION
- Clean backport of JDK-8336277.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8336277](https://bugs.openjdk.org/browse/JDK-8336277) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336277](https://bugs.openjdk.org/browse/JDK-8336277): Colors are incorrect when playing H.265/HEVC on Windows 11 (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx23u.git pull/7/head:pull/7` \
`$ git checkout pull/7`

Update a local copy of the PR: \
`$ git checkout pull/7` \
`$ git pull https://git.openjdk.org/jfx23u.git pull/7/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7`

View PR using the GUI difftool: \
`$ git pr show -t 7`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx23u/pull/7.diff">https://git.openjdk.org/jfx23u/pull/7.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx23u/pull/7#issuecomment-2272138857)