### PR TITLE
8338306: WebView Drag and Drop fails with WebKit 619.1

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebKitLegacy/java/WebCoreSupport/WebPage.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebKitLegacy/java/WebCoreSupport/WebPage.cpp
@@ -2250,8 +2250,10 @@ JNIEXPORT jint JNICALL Java_com_sun_webkit_WebPage_twkProcessDrag
         case com_sun_webkit_WebPage_DND_DST_EXIT:
             dc.dragExited(*localMainFrame,WTFMove(dragData));
             return 0;
+        case com_sun_webkit_WebPage_DND_DST_ENTER:
         case com_sun_webkit_WebPage_DND_DST_OVER:
-
+        case com_sun_webkit_WebPage_DND_DST_CHANGE:
+            return dragOperationToDragCursor(std::get<std::optional<WebCore::DragOperation>>(dc.dragEnteredOrUpdated(*localMainFrame, WTFMove(dragData))));
         case com_sun_webkit_WebPage_DND_DST_DROP:
             {
                 int ret = dc.performDragOperation(WTFMove(dragData)) ? 1 : 0;


### PR DESCRIPTION
Clean Backport

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8338306](https://bugs.openjdk.org/browse/JDK-8338306) needs maintainer approval

### Issue
 * [JDK-8338306](https://bugs.openjdk.org/browse/JDK-8338306): WebView Drag and Drop fails with WebKit 619.1 (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx23u.git pull/12/head:pull/12` \
`$ git checkout pull/12`

Update a local copy of the PR: \
`$ git checkout pull/12` \
`$ git pull https://git.openjdk.org/jfx23u.git pull/12/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12`

View PR using the GUI difftool: \
`$ git pr show -t 12`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx23u/pull/12.diff">https://git.openjdk.org/jfx23u/pull/12.diff</a>

</details>
