### PR TITLE
8338886: JavaFX debug builds fail on macOS

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/JavaDOMUtils.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/JavaDOMUtils.cpp
@@ -47,7 +47,7 @@ namespace WebCore {
 
 static void raiseDOMErrorException(JNIEnv* env, WebCore::ExceptionCode ec)
 {
-    ASSERT(ec);
+    ASSERT(ec == ExceptionCode::TypeError);
 
     auto description = DOMException::description(ec);
 


### PR DESCRIPTION
A clean backport to jfx23u. The fix is for a build error , failing to build on mac on debug mode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8338886](https://bugs.openjdk.org/browse/JDK-8338886) needs maintainer approval

### Issue
 * [JDK-8338886](https://bugs.openjdk.org/browse/JDK-8338886): JavaFX debug builds fail on macOS (**Bug** - P4 - Approved)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx23u.git pull/16/head:pull/16` \
`$ git checkout pull/16`

Update a local copy of the PR: \
`$ git checkout pull/16` \
`$ git pull https://git.openjdk.org/jfx23u.git pull/16/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16`

View PR using the GUI difftool: \
`$ git pr show -t 16`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx23u/pull/16.diff">https://git.openjdk.org/jfx23u/pull/16.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx23u/pull/16#issuecomment-2315470797)