### PR TITLE
8334124: Rendering issues with CSS "text-shadow" in WebView

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/GraphicsContextJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/GraphicsContextJava.cpp
@@ -1025,6 +1025,11 @@ void GraphicsContextJava::didUpdateState(GraphicsContextState& state)
         if (dropShadowOpt.has_value()) {
             const auto& dropShadow = dropShadowOpt.value();
             setPlatformShadow(dropShadow.offset,dropShadow.radius, dropShadow.color);
+        } else {
+            float clr = 0.0f;
+            platformContext()->rq().freeSpace(32)
+            << (jint)com_sun_webkit_graphics_GraphicsDecoder_SETSHADOW
+            << clr << clr << clr << clr << clr << clr << clr;
         }
     }
 

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/ShadowTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/ShadowTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.scene.web;
+
+import com.sun.webkit.WebPage;
+import com.sun.webkit.WebPageShim;
+import javafx.scene.web.WebEngineShim;
+import org.junit.Test;
+
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class ShadowTest extends TestBase {
+    /**
+     * @test
+     * @bug 8334124
+     * summary
+     * Paints an text with a red shadow, and another text without shadow.
+     * Checks by red pixel count if the shadow exists and only exists on the first text.
+     */
+    @Test public void testShadow() {
+        loadContent("<html>\n" +
+                    "<body style='margin: 0px;'>\n" +
+                    "<p style='text-shadow:5px 5px 0 #FF0000;height: 100px;'>text</p>\n" +
+                    "<p style='height: 100px'>text</p>\n" +
+                    "</body>\n" +
+                    "</html>");
+        submit(() -> {
+                final WebPage webPage = WebEngineShim.getPage(getEngine());
+                assertNotNull(webPage);
+                final BufferedImage img = WebPageShim.paint(webPage, 0, 0, 800, 600);
+                assertNotNull(img);
+
+                int redShadowCnt = 0;
+                int noShadowCnt = 0;
+                for (int x = 0; x < 100; x++) {
+                    for (int y = 0; y < 200; y++) {
+                        Color pixelColor = new Color(img.getRGB(x, y), true);
+                        if (isColorsSimilar(Color.RED, pixelColor, 1)) {
+                            if (y < 100) {
+                                redShadowCnt++;
+                            } else {
+                                noShadowCnt++;
+                            }
+                        }
+                    }
+                }
+
+                assertTrue("no shadow found", redShadowCnt > 0);
+                assertTrue("wrong shadow found", noShadowCnt == 0);
+        });
+    }
+}


### PR DESCRIPTION
A clean backport to jfx23u. The fix is for Rendering issues with CSS "text-shadow" in WebView . I have tested the fix it is working with the fix and failing without the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8334124](https://bugs.openjdk.org/browse/JDK-8334124) needs maintainer approval

### Issue
 * [JDK-8334124](https://bugs.openjdk.org/browse/JDK-8334124): Rendering issues with CSS "text-shadow" in WebView (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx23u.git pull/17/head:pull/17` \
`$ git checkout pull/17`

Update a local copy of the PR: \
`$ git checkout pull/17` \
`$ git pull https://git.openjdk.org/jfx23u.git pull/17/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17`

View PR using the GUI difftool: \
`$ git pr show -t 17`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx23u/pull/17.diff">https://git.openjdk.org/jfx23u/pull/17.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx23u/pull/17#issuecomment-2324608631)