### PR TITLE
8341911: Create release notes for JavaFX 23.0.1

### DIFF
--- a/doc-files/release-notes-23.0.1.md
+++ b/doc-files/release-notes-23.0.1.md
@@ -10,21 +10,21 @@ These notes document the JavaFX 23.0.1 update release. As such, they complement 
 
 Issue key | Summary | Subcomponent
 --------- | ------- | ------------
-[JDK-8334874](URL/JDK-8334874) | Horizontal scroll events from touch pads should scroll the TabPane tabs | controls
-[JDK-8323787](URL/JDK-8323787) | Mac System MenuBar throws IOB exception | graphics
-[JDK-8336277](URL/JDK-8336277) | Colors are incorrect when playing H.265/HEVC on Windows 11 | media
-[JDK-8336938](URL/JDK-8336938) | Update libFFI to 3.4.6 | media
-[JDK-8336939](URL/JDK-8336939) | Update Glib to 2.80.4 | media
-[JDK-8336940](URL/JDK-8336940) | Update GStreamer to 1.24.6 | media
-[JDK-8338701](URL/JDK-8338701) | Provide media support for libavcodec version 61 | media
-[JDK-8328994](URL/JDK-8328994) | Update WebKit to 619.1 | web
-[JDK-8334124](URL/JDK-8334124) | Rendering issues with CSS "text-shadow" in WebView | web
-[JDK-8336798](URL/JDK-8336798) | DRT test cssrounding.html test for linear layout fails with WebKit 619.1 | web
-[JDK-8336941](URL/JDK-8336941) | Update libxslt to 1.1.42 | web
-[JDK-8337481](URL/JDK-8337481) | File API: file.name contains path instead of name | web
-[JDK-8338306](URL/JDK-8338306) | WebView Drag and Drop fails with WebKit 619.1 | web
-[JDK-8338307](URL/JDK-8338307) | Additional WebKit 619.1 fixes from WebKitGTK 2.44.3 | web
-[JDK-8319779](URL/JDK-8319779) | SystemMenu: memory leak due to listener never being removed | window-toolkit
+[JDK-8334874](https://bugs.openjdk.org/browse/JDK-8334874) | Horizontal scroll events from touch pads should scroll the TabPane tabs | controls
+[JDK-8323787](https://bugs.openjdk.org/browse/JDK-8323787) | Mac System MenuBar throws IOB exception | graphics
+[JDK-8336277](https://bugs.openjdk.org/browse/JDK-8336277) | Colors are incorrect when playing H.265/HEVC on Windows 11 | media
+[JDK-8336938](https://bugs.openjdk.org/browse/JDK-8336938) | Update libFFI to 3.4.6 | media
+[JDK-8336939](https://bugs.openjdk.org/browse/JDK-8336939) | Update Glib to 2.80.4 | media
+[JDK-8336940](https://bugs.openjdk.org/browse/JDK-8336940) | Update GStreamer to 1.24.6 | media
+[JDK-8338701](https://bugs.openjdk.org/browse/JDK-8338701) | Provide media support for libavcodec version 61 | media
+[JDK-8328994](https://bugs.openjdk.org/browse/JDK-8328994) | Update WebKit to 619.1 | web
+[JDK-8334124](https://bugs.openjdk.org/browse/JDK-8334124) | Rendering issues with CSS "text-shadow" in WebView | web
+[JDK-8336798](https://bugs.openjdk.org/browse/JDK-8336798) | DRT test cssrounding.html test for linear layout fails with WebKit 619.1 | web
+[JDK-8336941](https://bugs.openjdk.org/browse/JDK-8336941) | Update libxslt to 1.1.42 | web
+[JDK-8337481](https://bugs.openjdk.org/browse/JDK-8337481) | File API: file.name contains path instead of name | web
+[JDK-8338306](https://bugs.openjdk.org/browse/JDK-8338306) | WebView Drag and Drop fails with WebKit 619.1 | web
+[JDK-8338307](https://bugs.openjdk.org/browse/JDK-8338307) | Additional WebKit 619.1 fixes from WebKitGTK 2.44.3 | web
+[JDK-8319779](https://bugs.openjdk.org/browse/JDK-8319779) | SystemMenu: memory leak due to listener never being removed | window-toolkit
 
 
 ## List of Security fixes

--- a/doc-files/release-notes-23.0.1.md
+++ b/doc-files/release-notes-23.0.1.md
@@ -34,6 +34,4 @@ Issue key | Summary | Subcomponent
 
 ## List of Security fixes
 
-Issue key | Summary | Subcomponent
---------- | ------- | ------------
-JDK-nnnnnnn (not public) | TITLE | SUBCOMPONENT
+NONE

--- a/doc-files/release-notes-23.0.1.md
+++ b/doc-files/release-notes-23.0.1.md
@@ -1,0 +1,34 @@
+# Release Notes for JavaFX 23.0.1
+
+## Introduction
+
+The following notes describe important changes and information about this release. In some cases, the descriptions provide links to additional detailed information about an issue or a change.
+
+These notes document the JavaFX 23.0.1 update release. As such, they complement the [JavaFX 23](https://github.com/openjdk/jfx23u/blob/master/doc-files/release-notes-23.md) release notes.
+
+## List of Fixed Bugs
+
+Issue key | Summary | Subcomponent
+--------- | ------- | ------------
+[JDK-8334874](URL/JDK-8334874) | Horizontal scroll events from touch pads should scroll the TabPane tabs | controls
+[JDK-8323787](URL/JDK-8323787) | Mac System MenuBar throws IOB exception | graphics
+[JDK-8336277](URL/JDK-8336277) | Colors are incorrect when playing H.265/HEVC on Windows 11 | media
+[JDK-8336938](URL/JDK-8336938) | Update libFFI to 3.4.6 | media
+[JDK-8336939](URL/JDK-8336939) | Update Glib to 2.80.4 | media
+[JDK-8336940](URL/JDK-8336940) | Update GStreamer to 1.24.6 | media
+[JDK-8338701](URL/JDK-8338701) | Provide media support for libavcodec version 61 | media
+[JDK-8328994](URL/JDK-8328994) | Update WebKit to 619.1 | web
+[JDK-8334124](URL/JDK-8334124) | Rendering issues with CSS "text-shadow" in WebView | web
+[JDK-8336798](URL/JDK-8336798) | DRT test cssrounding.html test for linear layout fails with WebKit 619.1 | web
+[JDK-8336941](URL/JDK-8336941) | Update libxslt to 1.1.42 | web
+[JDK-8337481](URL/JDK-8337481) | File API: file.name contains path instead of name | web
+[JDK-8338306](URL/JDK-8338306) | WebView Drag and Drop fails with WebKit 619.1 | web
+[JDK-8338307](URL/JDK-8338307) | Additional WebKit 619.1 fixes from WebKitGTK 2.44.3 | web
+[JDK-8319779](URL/JDK-8319779) | SystemMenu: memory leak due to listener never being removed | window-toolkit
+
+
+## List of Security fixes
+
+Issue key | Summary | Subcomponent
+--------- | ------- | ------------
+JDK-nnnnnnn (not public) | TITLE | SUBCOMPONENT

--- a/doc-files/release-notes-23.0.1.md
+++ b/doc-files/release-notes-23.0.1.md
@@ -6,11 +6,16 @@ The following notes describe important changes and information about this releas
 
 These notes document the JavaFX 23.0.1 update release. As such, they complement the [JavaFX 23](https://github.com/openjdk/jfx23u/blob/master/doc-files/release-notes-23.md) release notes.
 
+## List of Enhancements
+
+Issue Key | Summary | Subcomponent
+--------- | ------- | ------------
+[JDK-8334874](https://bugs.openjdk.org/browse/JDK-8334874) | Horizontal scroll events from touch pads should scroll the TabPane tabs | controls
+
 ## List of Fixed Bugs
 
 Issue key | Summary | Subcomponent
 --------- | ------- | ------------
-[JDK-8334874](https://bugs.openjdk.org/browse/JDK-8334874) | Horizontal scroll events from touch pads should scroll the TabPane tabs | controls
 [JDK-8323787](https://bugs.openjdk.org/browse/JDK-8323787) | Mac System MenuBar throws IOB exception | graphics
 [JDK-8336277](https://bugs.openjdk.org/browse/JDK-8336277) | Colors are incorrect when playing H.265/HEVC on Windows 11 | media
 [JDK-8336938](https://bugs.openjdk.org/browse/JDK-8336938) | Update libFFI to 3.4.6 | media


### PR DESCRIPTION
Release notes for JavaFX 23.0.1.

Notes to reviewers:

I used the following filter to pick the issues:

https://bugs.openjdk.org/issues/?filter=46412

The original filter, with the backport IDs, is here:

https://bugs.openjdk.org/issues/?filter=46411

As usual, I excluded test bugs, cleanup bugs, etc.

NOTE: Once the CPU release ships on 2024-10-15, I will add any security bugs and ask for a re-review.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8341911](https://bugs.openjdk.org/browse/JDK-8341911) needs maintainer approval

### Issue
 * [JDK-8341911](https://bugs.openjdk.org/browse/JDK-8341911): Create release notes for JavaFX 23.0.1 (**Task** - P2 - Approved)


### Reviewers
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx23u.git pull/24/head:pull/24` \
`$ git checkout pull/24`

Update a local copy of the PR: \
`$ git checkout pull/24` \
`$ git pull https://git.openjdk.org/jfx23u.git pull/24/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24`

View PR using the GUI difftool: \
`$ git pr show -t 24`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx23u/pull/24.diff">https://git.openjdk.org/jfx23u/pull/24.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx23u/pull/24#issuecomment-2405664854)