### PR TITLE
8341920: Intermittent WebKit build failure on Windows generating PDB files in 619.1

### DIFF
--- a/modules/javafx.web/src/main/native/Source/cmake/OptionsMSVC.cmake
+++ b/modules/javafx.web/src/main/native/Source/cmake/OptionsMSVC.cmake
@@ -117,8 +117,15 @@ if (NOT COMPILER_IS_CLANG_CL)
     )
 endif ()
 
-# Create pdb files for debugging purposes, also for Release builds
-add_compile_options(/Zi /GS)
+if (PORT STREQUAL "Java")
+    # Suppress creation of pdb files for Release builds
+    # FIXME: Need to re-enable the flag for Debug builds
+    #add_compile_options(/Zi /GS)
+
+else()
+    # Create pdb files for debugging purposes, also for Release builds
+    add_compile_options(/Zi /GS)
+endif()
 
 # Disable ICF (identical code folding) optimization,
 # as it makes it unsafe to pointer-compare functions with identical definitions.


### PR DESCRIPTION
Clean Backport

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8341920](https://bugs.openjdk.org/browse/JDK-8341920) needs maintainer approval

### Issue
 * [JDK-8341920](https://bugs.openjdk.org/browse/JDK-8341920): Intermittent WebKit build failure on Windows generating PDB files in 619.1 (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx23u.git pull/25/head:pull/25` \
`$ git checkout pull/25`

Update a local copy of the PR: \
`$ git checkout pull/25` \
`$ git pull https://git.openjdk.org/jfx23u.git pull/25/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25`

View PR using the GUI difftool: \
`$ git pr show -t 25`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx23u/pull/25.diff">https://git.openjdk.org/jfx23u/pull/25.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx23u/pull/25#issuecomment-2413492425)