### PR TITLE
8343760: GHA: macOS / aarch64 builds depend on Xcode 14 which will be removed

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -298,7 +298,8 @@ jobs:
           java -version
           which ant
           ant -version
-          sudo xcode-select --switch /Applications/Xcode_14.3.1.app/Contents/Developer
+          # We want to use Xcode 14, but GHA removed it from the macOS 14 runners
+          # sudo xcode-select --switch /Applications/Xcode_14.3.1.app/Contents/Developer
           xcodebuild -version
 
       - name: Build JavaFX artifacts


### PR DESCRIPTION
Clean backport of fix to avoid spurious GHA build failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8343760](https://bugs.openjdk.org/browse/JDK-8343760) needs maintainer approval

### Issue
 * [JDK-8343760](https://bugs.openjdk.org/browse/JDK-8343760): GHA: macOS / aarch64 builds depend on Xcode 14 which will be removed (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx23u.git pull/30/head:pull/30` \
`$ git checkout pull/30`

Update a local copy of the PR: \
`$ git checkout pull/30` \
`$ git pull https://git.openjdk.org/jfx23u.git pull/30/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30`

View PR using the GUI difftool: \
`$ git pr show -t 30`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx23u/pull/30.diff">https://git.openjdk.org/jfx23u/pull/30.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx23u/pull/30#issuecomment-2476231004)
</details>
