### PR TITLE
8333374: Cannot invoke "com.sun.prism.RTTexture.contentsUseful()" because "this.txt" is null

### DIFF
--- a/modules/javafx.web/src/main/java/com/sun/javafx/webkit/prism/RTImage.java
+++ b/modules/javafx.web/src/main/java/com/sun/javafx/webkit/prism/RTImage.java
@@ -115,6 +115,10 @@ final class RTImage extends PrismImage implements ResourceFactoryListener {
                     (int) Math.ceil(width * pixelScale),
                     (int) Math.ceil(height * pixelScale),
                     Texture.WrapMode.CLAMP_NOT_NEEDED);
+            if (txt == null) {
+                log.fine("RTImage::getTexture : return null because rt texture not allocated");
+                return null;
+            }
             txt.contentsUseful();
             txt.makePermanent();
             if (registeredWithFactory == null || registeredWithFactory.get() != f) {

--- a/modules/javafx.web/src/main/java/com/sun/javafx/webkit/prism/WCGraphicsPrismContext.java
+++ b/modules/javafx.web/src/main/java/com/sun/javafx/webkit/prism/WCGraphicsPrismContext.java
@@ -146,6 +146,11 @@ class WCGraphicsPrismContext extends WCGraphicsContext {
                     ? l.getGraphics()
                     : baseGraphics;
 
+            if (cachedGraphics == null) {
+                log.fine("getGraphics failed - couldn't acquire cachedGraphics");
+                return null;
+            }
+
             ResourceFactory rf = cachedGraphics.getResourceFactory();
             if (!rf.isDisposed()) {
                 state.apply(cachedGraphics);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [fb06b1f8](https://github.com/openjdk/jfx/commit/fb06b1f8e88d1c09cc8109ad3cb0ef5a5a754934) from the [openjdk/jfx](https://git.openjdk.org/jfx) repository.

The commit being backported was authored by Lukasz Kostyra on 10 Oct 2024 and was reviewed by Kevin Rushforth, Jose Pereda and Hima Bindu Meda.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8333374](https://bugs.openjdk.org/browse/JDK-8333374) needs maintainer approval

### Issue
 * [JDK-8333374](https://bugs.openjdk.org/browse/JDK-8333374): Cannot invoke "com.sun.prism.RTTexture.contentsUseful()" because "this.txt" is null (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx23u.git pull/32/head:pull/32` \
`$ git checkout pull/32`

Update a local copy of the PR: \
`$ git checkout pull/32` \
`$ git pull https://git.openjdk.org/jfx23u.git pull/32/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32`

View PR using the GUI difftool: \
`$ git pr show -t 32`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx23u/pull/32.diff">https://git.openjdk.org/jfx23u/pull/32.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx23u/pull/32#issuecomment-2497129364)
</details>
