### PR TITLE
8337827: [XWayland] Skip failing tests on Wayland

### DIFF
--- a/tests/system/src/test/java/test/robot/javafx/embed/swing/SwingNodeBase.java
+++ b/tests/system/src/test/java/test/robot/javafx/embed/swing/SwingNodeBase.java
@@ -191,11 +191,6 @@ public class SwingNodeBase {
         }
     }
 
-    private static boolean isOnWayland() {
-        String waylandDisplay = System.getenv("WAYLAND_DISPLAY");
-        return waylandDisplay != null && !waylandDisplay.isEmpty();
-    }
-
     public void testAbove(boolean above) {
         int checkLoc = BASE_LOCATION + 3 * BASE_SIZE /4;
         int clickLoc = BASE_LOCATION + BASE_SIZE / 4;
@@ -207,7 +202,7 @@ public class SwingNodeBase {
 
             // Emulating mouse clicks on XWayland with XTEST does not currently affect the Wayland compositor,
             // so trying to click on the window title or window body will not bring the window to the front.
-            if (isOnWayland()) {
+            if (Util.isOnWayland()) {
                 runWaitSleep(() -> myApp.stage.toFront());
             }
         }

--- a/tests/system/src/test/java/test/robot/javafx/embed/swing/SwingNodeJDialogTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/embed/swing/SwingNodeJDialogTest.java
@@ -32,10 +32,13 @@ import javax.swing.SwingUtilities;
 import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.CountDownLatch;
 
+import static org.junit.Assume.assumeTrue;
+
 public class SwingNodeJDialogTest extends SwingNodeBase {
 
     @Test(timeout = 15000)
     public void testJDialogAbove() throws InterruptedException, InvocationTargetException {
+        assumeTrue(!Util.isOnWayland()); // JDK-8335470
         myApp.createStageAndDialog();
         myApp.showDialog();
 
@@ -46,6 +49,7 @@ public class SwingNodeJDialogTest extends SwingNodeBase {
 
     @Test(timeout = 15000)
     public void testNodeRemovalAfterShow() throws InterruptedException, InvocationTargetException {
+        assumeTrue(!Util.isOnWayland()); // JDK-8335470
         myApp.createStageAndDialog();
         myApp.showDialog();
 
@@ -60,6 +64,7 @@ public class SwingNodeJDialogTest extends SwingNodeBase {
 
     @Test(timeout = 15000)
     public void testNodeRemovalBeforeShow() throws InterruptedException, InvocationTargetException {
+        assumeTrue(!Util.isOnWayland()); // JDK-8335470
         myApp.createStageAndDialog();
         myApp.detachSwingNode();
         myApp.showDialog();
@@ -72,6 +77,7 @@ public class SwingNodeJDialogTest extends SwingNodeBase {
 
     @Test(timeout = 15000)
     public void testStageCloseAfterShow() throws InvocationTargetException, InterruptedException {
+        assumeTrue(!Util.isOnWayland()); // JDK-8335470
         myApp.createStageAndDialog();
         myApp.showDialog();
         testAbove(true);
@@ -81,6 +87,7 @@ public class SwingNodeJDialogTest extends SwingNodeBase {
 
     @Test(timeout = 15000)
     public void testStageCloseBeforeShow() throws InvocationTargetException, InterruptedException {
+        assumeTrue(!Util.isOnWayland()); // JDK-8335470
         myApp.createStageAndDialog();
         myApp.closeStage();
         myApp.showDialog();
@@ -91,6 +98,7 @@ public class SwingNodeJDialogTest extends SwingNodeBase {
 
     @Test(timeout = 15000)
     public void testNodeRemovalBeforeShowHoldEDT() throws InterruptedException, InvocationTargetException {
+        assumeTrue(!Util.isOnWayland()); // JDK-8335470
         myApp.createAndShowStage();
         CountDownLatch latch = new CountDownLatch(1);
         SwingUtilities.invokeLater(()-> {
@@ -108,6 +116,7 @@ public class SwingNodeJDialogTest extends SwingNodeBase {
 
     @Test(timeout = 15000)
     public void testStageCloseBeforeShowHoldEDT() throws InvocationTargetException, InterruptedException {
+        assumeTrue(!Util.isOnWayland()); // JDK-8335470
         myApp.createAndShowStage();
         CountDownLatch latch = new CountDownLatch(1);
         SwingUtilities.invokeLater(()-> {

--- a/tests/system/src/test/java/test/util/Util.java
+++ b/tests/system/src/test/java/test/util/Util.java
@@ -48,6 +48,7 @@ import javafx.stage.Screen;
 import javafx.stage.Window;
 import org.junit.Assert;
 import junit.framework.AssertionFailedError;
+import com.sun.javafx.PlatformUtil;
 
 /**
  * Utility methods for life-cycle testing
@@ -489,5 +490,18 @@ public class Util {
             return 1.0;
         }
         return 0.0;
+    }
+
+
+    /**
+     * Checks if the system is running Linux with the Wayland server.
+     *
+     * @return true if running on Wayland, false otherwise
+     */
+    public static boolean isOnWayland() {
+        if (!PlatformUtil.isLinux()) return false;
+
+        String waylandDisplay = System.getenv("WAYLAND_DISPLAY");
+        return waylandDisplay != null && !waylandDisplay.isEmpty();
     }
 }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [0ee74e18](https://github.com/openjdk/jfx/commit/0ee74e185673fba03d490122d0560a181ebd6fb2) from the [openjdk/jfx](https://git.openjdk.org/jfx) repository.

The reason this backport is not clean is because the jfx23 does not have the `tests/system/src/test/java/test/robot/javafx/scene/SRGBTest.java`. So this change is skipped now.

The commit being backported was authored by Alexander Zvegintsev on 15 Aug 2024 and was reviewed by Kevin Rushforth.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8337827](https://bugs.openjdk.org/browse/JDK-8337827) needs maintainer approval

### Issue
 * [JDK-8337827](https://bugs.openjdk.org/browse/JDK-8337827): [XWayland] Skip failing tests on Wayland (**Bug** - P3 - Approved)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx23u.git pull/34/head:pull/34` \
`$ git checkout pull/34`

Update a local copy of the PR: \
`$ git checkout pull/34` \
`$ git pull https://git.openjdk.org/jfx23u.git pull/34/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 34`

View PR using the GUI difftool: \
`$ git pr show -t 34`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx23u/pull/34.diff">https://git.openjdk.org/jfx23u/pull/34.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx23u/pull/34#issuecomment-2498198854)
</details>
