### PR TITLE
8347616: Create release notes for JavaFX 23.0.2

### DIFF
--- a/doc-files/release-notes-23.0.2.md
+++ b/doc-files/release-notes-23.0.2.md
@@ -1,0 +1,21 @@
+# Release Notes for JavaFX 23.0.2
+
+## Introduction
+
+The following notes describe important changes and information about this release. In some cases, the descriptions provide links to additional detailed information about an issue or a change.
+
+These notes document the JavaFX 23.0.2 update release. As such, they complement the [JavaFX 23](https://github.com/openjdk/jfx23u/blob/master/doc-files/release-notes-23.md) and [JavaFX 23.0.1](https://github.com/openjdk/jfx23u/blob/master/doc-files/release-notes-23.0.1.md) release notes.
+
+## List of Fixed Bugs
+
+Issue key | Summary | Subcomponent
+--------- | ------- | ------------
+[JDK-8333374](https://bugs.openjdk.org/browse/JDK-8333374) | Cannot invoke "com.sun.prism.RTTexture.contentsUseful()" because "this.txt" is null | graphics
+[JDK-8340208](https://bugs.openjdk.org/browse/JDK-8340208) | Additional WebKit 619.1 fixes from WebKitGTK 2.44.4 | web
+[JDK-8335469](https://bugs.openjdk.org/browse/JDK-8335469) | [XWayland] crash when an AWT ScreenCast session overlaps with an FX ScreenCast session | window-toolkit
+
+## List of Security fixes
+
+Issue key | Summary | Subcomponent
+--------- | ------- | ------------
+JDK-nnnnnnn (not public) | TITLE | SUBCOMPONENT

--- a/doc-files/release-notes-23.0.2.md
+++ b/doc-files/release-notes-23.0.2.md
@@ -18,4 +18,5 @@ Issue key | Summary | Subcomponent
 
 Issue key | Summary | Subcomponent
 --------- | ------- | ------------
-JDK-nnnnnnn (not public) | TITLE | SUBCOMPONENT
+JDK-8335714 (not public) | Enhance playing MP3s | media
+JDK-8335715 (not public) | Improve Direct Show support | media


### PR DESCRIPTION
Release notes for JavaFX 23.0.2.

Notes to reviewers:

I used the following filter to pick the issues:

https://bugs.openjdk.org/issues/?filter=47027

The original filter, with the backport IDs, is here:

https://bugs.openjdk.org/issues/?filter=47026

As usual, I excluded test bugs, cleanup bugs, etc.

NOTE: Once the CPU release ships on 2025-01-21, I will add any security bugs and ask for a re-review.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8347616](https://bugs.openjdk.org/browse/JDK-8347616) needs maintainer approval

### Issue
 * [JDK-8347616](https://bugs.openjdk.org/browse/JDK-8347616): Create release notes for JavaFX 23.0.2 (**Task** - P3 - Approved)


### Reviewers
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**)

### Reviewers without OpenJDK IDs
 * @abhinayagarwal (no known openjdk.org user name / role) Review applies to [61842b2c](https://git.openjdk.org/jfx23u/pull/35/files/61842b2cb3fc216e2bcd6650c9b49391232ba34d)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx23u.git pull/35/head:pull/35` \
`$ git checkout pull/35`

Update a local copy of the PR: \
`$ git checkout pull/35` \
`$ git pull https://git.openjdk.org/jfx23u.git pull/35/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 35`

View PR using the GUI difftool: \
`$ git pr show -t 35`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx23u/pull/35.diff">https://git.openjdk.org/jfx23u/pull/35.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx23u/pull/35#issuecomment-2587975852)
</details>
